### PR TITLE
clean up the indentation config

### DIFF
--- a/syntax-color-lib/syntax-color/private/racket-tabify.rkt
+++ b/syntax-color-lib/syntax-color/private/racket-tabify.rkt
@@ -32,22 +32,16 @@
               '(for/fold for/fold: for*/fold for*/fold:
                  for/lists for/lists: for*/lists for*/lists:))
     (for-each (λ (x) (hash-set! defaults-ht x 'define))
-              '(struct
-                 local
-                 
-                 struct: define-struct: define-typed-struct define-struct/exec:
-                 define: pdefine:
-                 define-type define-predicate
-                 match-define match-define-values))
+              '(struct local struct: pdefine: match-define match-define-values))
     (for-each (λ (x) (hash-set! defaults-ht x 'begin))
               '(case-lambda case-lambda: pcase-lambda:
                             match-lambda match-lambda*
                             syntax-parser
                             cond
                             delay
-                            unit compound-unit compound-unit/sig
+                            unit compound-unit
                             public private override require
-                            inherit sequence
+                            inherit
                             ;; Explicitly indent these with- constructs using begin-like style
                             ;; for otherwise they will be captured by the regexp of lambda-like style
                             with-output-to-string with-output-to-bytes
@@ -67,8 +61,8 @@
                 with-continuation-mark
                 module module* module+
                 match match-let match-let* match-letrec
-                let/cc let/ec letcc catch
-                let-syntax letrec-syntax fluid-let-syntax letrec-syntaxes+values
+                let/cc let/ec
+                let-syntax letrec-syntax letrec-syntaxes+values
                 
                 let: letrec: let*:
                 let-values: letrec-values: let*-values:
@@ -87,26 +81,23 @@
                 kernel-syntax-case
                 syntax-case syntax-case* syntax-rules syntax-id-rules
                 syntax-parse
-                let-signature fluid-let
-                let-struct let-macro let-values let*-values
+                fluid-let
+                let-struct let-values let*-values
                 case when unless 
-                let-enumerate
-                class class* class-asi class-asi* class*/names
-                class100 class100* class100-asi class100-asi* class100*/names
+                class class*
                 rec
                 make-object mixin
-                define-some do opt-lambda
+                do opt-lambda
                 send* with-method
                 define-record
-                catch shared
-                unit/sig unit/lang
+                shared
                 with-handlers
                 interface
                 parameterize parameterize* syntax-parameterize
                 call-with-input-file call-with-input-file* with-input-from-file
                 with-input-from-string
-                with-input-from-port call-with-output-file
-                with-output-to-file with-output-to-port 
+                call-with-output-file
+                with-output-to-file
 
                 for-all
 


### PR DESCRIPTION
Remove entries that are not documented. These are:
- compound-unit/sig
- sequence
- letcc
- catch
- fluid-let-syntax
- let-signature
- let-macro
- let-enumerate
- class-asi(*)
- class*/names
- class100...
- define-some
- unit/sig
- unit/lang
- with-input-from-port
- with-output-to-port

Also remove entries that are already included by regex