### PR TITLE
handle dont-stop struct in module-lexer correctly

### DIFF
--- a/syntax-color-lib/syntax-color/module-lexer.rkt
+++ b/syntax-color-lib/syntax-color/module-lexer.rkt
@@ -133,16 +133,19 @@ to delegate to the racket-lexer (in the no-lang-line mode).
         (define-values (lexeme type data new-token-start new-token-end)
           (racket-lexer in))
         (values lexeme type data new-token-start new-token-end 0 mode)])]
-    [(pair? mode)
+    [(or (pair? mode) (dont-stop? mode))
      ;; #lang-selected language consumes and produces a mode:
+     (define pair-mode (if (dont-stop? mode) (dont-stop-val mode) mode))
+     (define lexer (car pair-mode))
+     (define inner-mode (cdr pair-mode))
      (let-values ([(lexeme type data new-token-start new-token-end backup-delta new-mode)
-                   ((car mode) in offset (cdr mode))])
+                   (lexer in offset inner-mode)])
        (values lexeme
                (if can-return-attribs-hash? type (attribs->symbol type))
                data new-token-start new-token-end backup-delta
                (if (dont-stop? new-mode)
-                   (dont-stop (cons (car mode) (dont-stop-val new-mode)))
-                   (cons (car mode) new-mode))))]
+                   (dont-stop (cons lexer (dont-stop-val new-mode)))
+                   (cons lexer new-mode))))]
     [else
      ;; #lang-selected language (or default) doesn't deal with modes:
      (let-values ([(lexeme type data new-token-start new-token-end) 


### PR DESCRIPTION
I encountered this problem during writing Rhombus with @yjqww6 's drcomplete:
![9M4MG}T56) ~LX4QT4GD~1Y](https://github.com/racket/syntax-color/assets/22510026/aad1c3a1-3afc-4b5c-be24-aa4e7a015cb9)

The following code could reproduce the same error:
```racket
#lang racket
(require syntax-color/module-lexer)

(define (symbols in)
  (let loop ([mode #f] [s (set)])
    (define-values (str type _1 _2 _3 _4 new-mode)
      (module-lexer in 0 mode))
    (cond
      [(or (eof-object? str) (eq? type 'eof)) s]
      [(and (eq? type 'symbol) (string? str))
       (loop new-mode (set-add s str))]
      [else (loop new-mode s)])))

(define s 
#<<rhombus
#lang rhombus

macro 'test $x':
  '$x'

test
rhombus
  )

(symbols (open-input-string s))
```
It's obvious that module-lexer doesn't recognize pair mode wrapped by `dont-struct` struct and then treats it as a lexer procedure in the last `else` clause.