### PR TITLE
Fix doc typo of `check-colorer-results-match-port`

### DIFF
--- a/syntax-color-doc/syntax-color/syntax-color.scrbl
+++ b/syntax-color-doc/syntax-color/syntax-color.scrbl
@@ -53,7 +53,7 @@ class of @racketmodname[framework].
   see @xmethod[color:text<%> start-colorer].
 }
 
-@defproc[(check-colorer-results-match-port-before-and-afters
+@defproc[(check-colorer-results-match-port-before-and-after
           [who symbol?]
           [type any/c]
           [pos-before (or/c exact-positive-integer? #f)]


### PR DESCRIPTION
There was an extra `s` at the end.